### PR TITLE
Bump cabal constraints on base

### DIFF
--- a/counter.cabal
+++ b/counter.cabal
@@ -16,7 +16,7 @@ build-type:    Simple
 cabal-version: >=1.10
 
 library
-  build-depends:     base >=4.8 && <4.9,
+  build-depends:     base >=4.8 && <5,
                      containers >=0.5 && <0.6
   exposed-modules:   Data.Counter
   hs-source-dirs:    src 

--- a/counter.cabal
+++ b/counter.cabal
@@ -1,5 +1,5 @@
 name:          counter
-version:       0.1.0.1
+version:       0.1.0.2
 synopsis:      An object frequency counter.
 description:   This project provides an efficient object frequency counter, based upon Data.Map.Strict.
 homepage:      https://github.com/wei2912/counter


### PR DESCRIPTION
Make the package work with `base <5` and GHC 8.